### PR TITLE
增加物品终端

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ group = "top.limbang"
 version = "0.0.1"
 
 repositories {
+    maven { url = uri("https://maven.aliyun.com/repository/public")}
     mavenCentral()
     maven { url = uri("https://jitpack.io") }
 }
@@ -30,6 +31,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+    implementation("com.github.promeg:tinypinyin:2.0.3")                        // TinyPinyin核心包，约80KB
+    implementation("com.github.promeg:tinypinyin-lexicons-java-cncity:2.0.3")  // 可选，适用于Java的中国地区词典
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion")

--- a/src/main/kotlin/entity/AeCommand.kt
+++ b/src/main/kotlin/entity/AeCommand.kt
@@ -42,9 +42,21 @@ sealed class AeCommand(val commandString: String) {
     /**
      * 获取所有物品命令
      */
-    data class GetAllItems(val filter: Item?) : AeCommand(
-        "return ae.getAllItems(${filter?.let { "{name = \"${it.name}\",damage = ${it.damage}}" } ?: ""})")
+    data class GetSingleItem(val name: String?, val damage: Int?) : AeCommand(
+        "return ae.getSingleItems(${
+            if (name != null) {
+                if (damage != null) {
+                    "{name = \"$name\",damage = $damage}"
+                } else {
+                    "{name = \"$name\"}"
+                }
+            } else {"{}"}
+        })"
+    )
 
+    data class GetAllItems(val filterJson: String?) : AeCommand(
+        "return ae.getAllItems(${filterJson ?: ""})"
+    )
     /**
      * 请求物品命令
      * @param itemName 物品名称

--- a/src/main/kotlin/entity/Item.kt
+++ b/src/main/kotlin/entity/Item.kt
@@ -155,3 +155,15 @@ data class LocalizedData(
     val size: Long,
     val isFluid: Boolean = false
 )
+
+/**
+ * 物品查询数据实体
+ * 用于物品终端过滤查询
+ * @property name 唯一命名空间标识符
+ * @property damage 损伤值或元数据标识，用于区分同类物品的不同状态。
+ */
+@Serializable
+data class searchItem(
+    val name: String,
+    val damage: Int,
+)

--- a/src/main/kotlin/listener/ClientListener.kt
+++ b/src/main/kotlin/listener/ClientListener.kt
@@ -24,6 +24,8 @@ import top.limbang.remoteoc.listener.TeamListener.sendMessage
 import top.limbang.remoteoc.network.model.ResultData
 import top.limbang.remoteoc.utils.*
 import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -35,6 +37,7 @@ object ClientListener : SimpleListenerHost() {
     private val BIND_CLIENT_REGEX = """^绑定客户端\s?([a-zA-Z0-9]{2,16})(?:\s+(true|false))?""".toRegex()
     private val CRAFT_ITEM_REGEX = """^合成\s+([^\s\n]+(?:\s+[^\s\n]+)*?)(?:\s+(\d{1,12}))?$""".toRegex()
     private val CANCEL_CRAFTING_REGEX = """^取消合成\s+(.*)""".toRegex()
+    private val ITEM_QUERY_REGEX = """^物品终端\s+([^\s\n]+(?:\s+[^\s\n]+)*)$""".toRegex()
 
     // 物品本地化工具
     private val itemUtil = ItemUtil(dataFolderPath.toString())
@@ -154,6 +157,55 @@ object ClientListener : SimpleListenerHost() {
         result?.data ?: run { sendMessage("❌ 获取CPU信息失败"); return }
         // 发送CPU信息图片
         sendImage(result.data.toImage(itemUtil))
+    }
+    /**
+     * 物品终端查询功能
+     */
+    @EventHandler
+    suspend fun GroupMessageEvent.getAllItems() {
+        // 1. 确认消息包含 "物品终端"
+        val content = message.contentToString()
+        if (!ITEM_QUERY_REGEX.matches(content)) return
+
+        // 2. 获取团队信息
+        val team = validateTeamAndClient() ?: return
+
+
+        // 3. 获取所有查询的本地化名称
+        val queryItems = content.removePrefix("物品终端").trim().split(" ")
+        val items = itemUtil.searchItemsByNames(queryItems)
+
+        if (items.isEmpty()) {
+            sendMessage("❌ 数据库没有任何匹配的物品")
+            return
+        }
+
+        val allData = mutableListOf<LocalizedData>()
+
+        // 4. 批量处理物品查询
+        if(items.size > 2)
+        {
+            val firstItem = items.first()
+            val result = sendCommandRequest(team, AeCommand.GetAllItems(firstItem), Item.serializer())
+            if (result?.data == null) {
+                // sendMessage("❌ 获取物品终端失败: ${firstItem.name}")
+                return
+            }
+            allData.addAll(itemUtil.getLocalizedDataList(result.data!!))
+        }
+        else items.forEach { item ->
+            val result = sendCommandRequest(team, AeCommand.GetAllItems(item), Item.serializer())
+            if (result?.data == null) {
+                //sendMessage("❌ 获取物品终端失败: ${item.name}")
+                return
+            }
+            allData.addAll(itemUtil.getLocalizedDataList(result.data!!))
+        }
+
+        //返回图片
+        if (allData.isNotEmpty()) {
+            sendImage(allData.toImage("物品终端"))
+        }
     }
 
     /**
@@ -323,3 +375,5 @@ object ClientListener : SimpleListenerHost() {
     }
 
 }
+
+

--- a/src/main/kotlin/listener/ClientListener.kt
+++ b/src/main/kotlin/listener/ClientListener.kt
@@ -9,6 +9,7 @@ package top.limbang.remoteoc.listener
 
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.KSerializer
+
 import net.mamoe.mirai.contact.Contact.Companion.uploadImage
 import net.mamoe.mirai.event.EventHandler
 import net.mamoe.mirai.event.SimpleListenerHost
@@ -183,29 +184,23 @@ object ClientListener : SimpleListenerHost() {
         val allData = mutableListOf<LocalizedData>()
 
         // 4. 批量处理物品查询
-        if(items.size > 2)
+        if(items.size < 2)
         {
             val firstItem = items.first()
-            val result = sendCommandRequest(team, AeCommand.GetAllItems(firstItem), Item.serializer())
-            if (result?.data == null) {
-                // sendMessage("❌ 获取物品终端失败: ${firstItem.name}")
-                return
-            }
-            allData.addAll(itemUtil.getLocalizedDataList(result.data!!))
+            val result = sendCommandRequest(team, AeCommand.GetSingleItem(firstItem.name,firstItem.damage), Item.serializer())
+            if (result?.data == null) return
+            allData.addAll(itemUtil.getLocalizedDataList(result.data))
         }
-        else items.forEach { item ->
-            val result = sendCommandRequest(team, AeCommand.GetAllItems(item), Item.serializer())
-            if (result?.data == null) {
-                //sendMessage("❌ 获取物品终端失败: ${item.name}")
-                return
-            }
-            allData.addAll(itemUtil.getLocalizedDataList(result.data!!))
+        else {
+            val result = sendCommandRequest(team, AeCommand.GetAllItems(convertToLuaTable(items)), Item.serializer())
+            if (result?.data == null) return
+            allData.addAll(itemUtil.getLocalizedDataList(result.data))
         }
 
         //返回图片
         if (allData.isNotEmpty()) {
             sendImage(allData.toImage("物品终端"))
-        }
+        }else sendMessage("❌ 未找到物品");
     }
 
     /**
@@ -329,6 +324,18 @@ object ClientListener : SimpleListenerHost() {
         sendMessage(result?.message ?: "❌ 取消合成失败：未知原因")
     }
 
+    /**
+     * 将物品列表转换为 Lua 表格式
+     *
+     * @param items 待查询的物品列表
+     * @return Lua 表格式的字符串
+     */
+    private fun convertToLuaTable(items: List<searchItem>): String {
+        return items.joinToString(prefix = "{", postfix = "}") { item ->
+            val damagePart = item.damage?.let { ", damage=$it" } ?: ""
+            "{name=\"${item.name}\"$damagePart}"
+        }
+    }
     /**
      * 发送命令请求
      *

--- a/src/main/kotlin/utils/ItemUtil.kt
+++ b/src/main/kotlin/utils/ItemUtil.kt
@@ -47,10 +47,8 @@ class ItemUtil(
             ?: throw IllegalArgumentException("液体数据文件不存在: $resourceDir/$fluidsJsonName")
 
         // 加载物品数据,自动关闭流
-        itemData = itemFile.reader(Charsets.UTF_8).use { Json.decodeFromString(it.readText()) }
         itemData = itemFile.reader(Charsets.UTF_8).use { json.decodeFromString(it.readText()) }
         // 加载液体数据,自动关闭流
-        fluidData = fluidFile.reader(Charsets.UTF_8).use { Json.decodeFromString(it.readText()) }
         fluidData = fluidFile.reader(Charsets.UTF_8).use { json.decodeFromString(it.readText()) }
 
         // 构建索引逻辑
@@ -145,8 +143,8 @@ class ItemUtil(
         return results.distinct()
     }
 
-    fun searchItemsByNames(queries: List<String>): List<Item> {
-        val results = mutableListOf<Item>()
+    fun searchItemsByNames(queries: List<String>): List<searchItem> {
+        val results = mutableListOf<searchItem>()
         // 遍历每个查询
         queries.forEach { query ->
             var chineseResultCount = 0
@@ -159,7 +157,7 @@ class ItemUtil(
                     val pattern = Regex("^$regex$") // 添加 ^ 和 $ 确保匹配整个字符串
                     localizedIndex.forEach { (key, value) ->
                         if (pattern.matches(key)) {
-                            val item = Item(value.first, damage = value.second, label = key, size = 0)
+                            val item = searchItem(value.first, value.second)
                             results.add(item)
                             chineseResultCount++
                         }
@@ -167,7 +165,7 @@ class ItemUtil(
                 } else {
                     // 精确查询
                     localizedIndex[query]?.let { (name, damage) ->
-                        val item = Item(name, damage = damage, label = query, size = 0)
+                        val item = searchItem(name, damage)
                         results.add(item)
                         chineseResultCount++
                     }
@@ -183,7 +181,7 @@ class ItemUtil(
                     pinyinIndex.forEach { (key, mappings) ->
                         if (pattern.matches(key)) {
                             mappings.forEach { (name, damage) ->
-                                results.add(Item(name, damage = damage, label = query, size = 0))
+                                results.add(searchItem(name, damage))
                             }
                         }
                     }
@@ -191,7 +189,7 @@ class ItemUtil(
                     // 拼音精确查询
                     pinyinIndex[pinyinQuery]?.let { mappings ->
                         mappings.forEach { (name, damage) ->
-                            results.add(Item(name, damage = damage, label = query, size = 0))
+                            results.add(searchItem(name, damage))
                         }
                     }
                 }

--- a/src/main/kotlin/utils/ItemUtil.kt
+++ b/src/main/kotlin/utils/ItemUtil.kt
@@ -8,6 +8,7 @@
 package top.limbang.remoteoc.utils
 
 
+import com.github.promeg.pinyinhelper.Pinyin
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import top.limbang.remoteoc.entity.*
@@ -36,6 +37,8 @@ class ItemUtil(
     private val itemData: Map<String, Map<String, ItemMetadata>>
     private val fluidData: Map<String, FluidMetadata>
 
+    private val localizedIndex = mutableMapOf<String, Pair<String, Int>>()
+    private val pinyinIndex = mutableMapOf<String, MutableList<Pair<String, Int>>>()
     init {
         // 检查资源目录是否存在
         val itemFile = File(resourceDir, itemJsonName).takeIf { it.exists() }
@@ -44,9 +47,43 @@ class ItemUtil(
             ?: throw IllegalArgumentException("液体数据文件不存在: $resourceDir/$fluidsJsonName")
 
         // 加载物品数据,自动关闭流
+        itemData = itemFile.reader(Charsets.UTF_8).use { Json.decodeFromString(it.readText()) }
         itemData = itemFile.reader(Charsets.UTF_8).use { json.decodeFromString(it.readText()) }
         // 加载液体数据,自动关闭流
+        fluidData = fluidFile.reader(Charsets.UTF_8).use { Json.decodeFromString(it.readText()) }
         fluidData = fluidFile.reader(Charsets.UTF_8).use { json.decodeFromString(it.readText()) }
+
+        // 构建索引逻辑
+        itemData.forEach { (itemId, metas) ->
+            metas.forEach { (metaStr, entry) ->
+                metaStr.toIntOrNull()?.let { meta ->
+                    val pair = itemId to meta
+
+                    // 1. 构建原始名称索引
+                    localizedIndex[entry.localizedName] = pair
+
+                    // 2. 生成拼音索引（处理多音字）
+                    val pinyin = generatePinyinVariations(entry.localizedName) // 只返回一个拼音变体
+                    pinyinIndex.computeIfAbsent(pinyin) { mutableListOf() }.add(pair)
+                }
+            }
+        }
+    }
+
+    /**
+     * 生成拼音变体（处理多音字）
+     */
+    fun generatePinyinVariations(chinese: String): String {
+        val words = chinese.toCharArray()
+        val pinyinList = words.map { char ->
+            if (Pinyin.isChinese(char)) {
+                Pinyin.toPinyin(char).lowercase() // `拼音` 转 `pinyin`
+            } else {
+                char.toString().lowercase() // 非汉字直接保留
+            }
+        }
+        // 组合所有可能的拼音变体
+        return pinyinList.joinToString("") //setOf(pinyinList.joinToString(""), pinyinList.joinToString(" "))
     }
 
     /**
@@ -77,6 +114,92 @@ class ItemUtil(
         if (item.isFluidDrop()) return handleFluidDrop(item)
         // 常规物品处理流程
         return handleRegularItem(item)
+    }
+
+    /**
+     * 通过本地化名字或拼音查询 itemId 和 damage，支持模糊匹配
+     */
+    fun searchItemByName(query: String): List<Item> {
+        val results = mutableListOf<Item>()
+
+        // 中文直接查询
+//        localizedIndex[query]?.let {
+//            results.add(Item(name, damage = damage, label = query, size = 0))
+//        }
+        // 模糊匹配：查找包含 query 的本地化名称
+        localizedIndex.filterKeys { it.contains(query) }.values.forEach { (name, damage) ->
+            results.add(Item(name, damage = damage, label = query, size = 0))
+        }
+
+        // 拼音查询（支持多种拼音格式）
+//       val pinyinQuery = query.lowercase()
+//        pinyinIndex[pinyinQuery]?.let {
+//            results.add(Item(name, damage = damage, label = query, size = 0))
+//        }
+
+        // 拼音模糊匹配
+        val pinyinQuery = query.lowercase()
+        pinyinIndex.filterKeys { it.contains(pinyinQuery) }.values.flatten().forEach { (name, damage) ->
+            results.add(Item(name, damage = damage, label = query, size = 0))
+        }
+        return results.distinct()
+    }
+
+    fun searchItemsByNames(queries: List<String>): List<Item> {
+        val results = mutableListOf<Item>()
+        // 遍历每个查询
+        queries.forEach { query ->
+            var chineseResultCount = 0
+            val isChinese = query.any { Pinyin.isChinese(it) }
+
+            if (isChinese) {
+                if (query.contains("*")) {
+                    // 模糊查询
+                    val regex = query.replace("*", ".*") // 将 * 替换为 .*
+                    val pattern = Regex("^$regex$") // 添加 ^ 和 $ 确保匹配整个字符串
+                    localizedIndex.forEach { (key, value) ->
+                        if (pattern.matches(key)) {
+                            val item = Item(value.first, damage = value.second, label = key, size = 0)
+                            results.add(item)
+                            chineseResultCount++
+                        }
+                    }
+                } else {
+                    // 精确查询
+                    localizedIndex[query]?.let { (name, damage) ->
+                        val item = Item(name, damage = damage, label = query, size = 0)
+                        results.add(item)
+                        chineseResultCount++
+                    }
+                }
+            }
+
+            if (chineseResultCount < 2) {
+                val pinyinQuery = query.lowercase()
+                if (pinyinQuery.contains("*")) {
+                    // 拼音模糊查询
+                    val regex = pinyinQuery.replace("*", ".*")
+                    val pattern = Regex("^$regex$")
+                    pinyinIndex.forEach { (key, mappings) ->
+                        if (pattern.matches(key)) {
+                            mappings.forEach { (name, damage) ->
+                                results.add(Item(name, damage = damage, label = query, size = 0))
+                            }
+                        }
+                    }
+                } else {
+                    // 拼音精确查询
+                    pinyinIndex[pinyinQuery]?.let { mappings ->
+                        mappings.forEach { (name, damage) ->
+                            results.add(Item(name, damage = damage, label = query, size = 0))
+                        }
+                    }
+                }
+            }
+        }
+
+        // 返回去重后的结果
+        return results.distinct()
     }
 
     /**

--- a/src/test/kotlin/listener/ClientListenerTest.kt
+++ b/src/test/kotlin/listener/ClientListenerTest.kt
@@ -90,11 +90,11 @@ internal class ClientListenerTest {
 
         val result = sendCommandRequest(
             clientId = clientId,
-            aeCommand = AeCommand.GetAllItems(item),
+            aeCommand = AeCommand.GetSingleItem(item.name,item.damage),
             serializer = Item.serializer()
         )
         result?.data ?: run { logger.error("❌ 获取物品终端失败"); return@runBlocking }
-        val image = itemUtil.getLocalizedDataList(result.data!!).toImage("物品终端")
+        val image = itemUtil.getLocalizedDataList(result.data!!).toImage("[{name:\"minecraft:redstone\"},{name:\"minecraft:glass\"}]")
         ImageIO.write(image, "PNG", File("物品终端.png"))
         logger.info(result.data.toString())
     }

--- a/src/test/kotlin/utils/ItemUtilTest.kt
+++ b/src/test/kotlin/utils/ItemUtilTest.kt
@@ -1,6 +1,6 @@
 package top.limbang.remoteoc.utils
 
-import kotlinx.serialization.json.Json
+import junit.framework.TestCase.assertEquals
 import top.limbang.remoteoc.entity.Item
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -26,4 +26,119 @@ internal class ItemUtilTest {
     }
 
 
+}
+
+
+class PinyinTest {
+    private val itemUtil = ItemUtil("debug-sandbox/data/top.limbang.RemoteOC")
+
+    /**
+     * 测试纯中文字符（无多音字）
+     */
+    @Test
+    fun testAllChineseNoPolyphone() {
+        val input = "你好"
+        val expected = "nihao"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testAllChineseNoPolyphone: input = '$input', expected = $expected, result = $result")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试包含多音字的中文字符（假设库返回第一个拼音）
+     */
+    @Test
+    fun testChineseWithPolyphone() {
+        val input = "重庆"
+        // 假设 "重" 返回 "zhong"，"庆" 返回 "qing"
+        val expected = "zhongqing"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testChineseWithPolyphone: input = '$input', expected = $expected, result = $result")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试混合中英文、数字、符号
+     */
+    @Test
+    fun testMixedCharacters() {
+        val input = "a你b好123@"
+        val expected = "anibhao123@"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testMixedCharacters: input = '$input', expected = $expected, result = $result")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试空字符串
+     */
+    @Test
+    fun testEmptyString() {
+        val input = ""
+        val expected = ""  // 空字符串应该返回空字符串
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testEmptyString: input = '$input', expected = '$expected', result = '$result'")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试非中文字符（字母、数字）
+     */
+    @Test
+    fun testNonChineseCharacters() {
+        val input = "abc123"
+        val expected = "abc123"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testNonChineseCharacters: input = '$input', expected = '$expected', result = '$result'")
+        assertEquals(expected, result)
+    }
+}
+
+class ItemUtilTestByName {
+    private val itemUtil = ItemUtil("debug-sandbox/data/top.limbang.RemoteOC")
+
+    @Test
+    fun `test search item by exact name - silver wire`() {
+        val results = itemUtil.searchItemByName("1x银导线")
+        println("Search results for '1x银导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 100, label = "1x银导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+
+    }
+
+    @Test
+    fun `test search item by exact name - tin wire`() {
+        val results = itemUtil.searchItemByName("1x锡导线")
+        println("Search results for '1x锡导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 112, label = "1x锡导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
+
+    @Test
+    fun `test search item by exact name - tungsten wire`() {
+        val results = itemUtil.searchItemByName("1x钨导线")
+        println("Search results for '1x钨导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 115, label = "1x钨导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
+
+    @Test
+    fun `test search item by non-existent name`() {
+        val results = itemUtil.searchItemByName("1x金导线")  // 假设"金导线"不存在
+        println("Search results for '1x金导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 41, label = "1x金导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
+
+    @Test
+    fun `test search item by pinyin with different case`() {
+        val results = itemUtil.searchItemByName("jindaoxian")  // 拼音的不同大小写
+        println("Search results for 'jindaoxian': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 41, label = "1x金导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
 }


### PR DESCRIPTION
增加物品终端指令,因为OC内存限制,仅支持物品过滤查询
1. 使用方法: 物品终端 [过滤1] [过滤2]...  
2. 支持使用全拼代替汉字; 汉字不匹配时, 会尝试使用输入汉字的拼音进行查询
3. 使用* 进行模糊匹配
例如: 物品终端 hongshi 铁*   可以过滤终端中的红石, 铁锭\铁块\铁砧\铁门 等 并返回
需要同步更新ae.lua 支持多物品查询