### PR TITLE
增加物品终端

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ group = "top.limbang"
 version = "0.0.1"
 
 repositories {
+    maven { url = uri("https://maven.aliyun.com/repository/public")}
     mavenCentral()
     maven { url = uri("https://jitpack.io") }
 }
@@ -30,6 +31,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+    implementation("com.github.promeg:tinypinyin:2.0.3")                        // TinyPinyin核心包，约80KB
+    implementation("com.github.promeg:tinypinyin-lexicons-java-cncity:2.0.3")  // 可选，适用于Java的中国地区词典
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion")

--- a/src/main/kotlin/entity/AeCommand.kt
+++ b/src/main/kotlin/entity/AeCommand.kt
@@ -42,9 +42,21 @@ sealed class AeCommand(val commandString: String) {
     /**
      * 获取所有物品命令
      */
-    data class GetAllItems(val filter: Item?) : AeCommand(
-        "return ae.getAllItems(${filter?.let { "{name = \"${it.name}\",damage = ${it.damage}}" } ?: ""})")
+    data class GetSingleItem(val name: String?, val damage: Int?) : AeCommand(
+        "return ae.getSingleItems(${
+            if (name != null) {
+                if (damage != null) {
+                    "{name = \"$name\",damage = $damage}"
+                } else {
+                    "{name = \"$name\"}"
+                }
+            } else {"{}"}
+        })"
+    )
 
+    data class GetAllItems(val filterJson: String?) : AeCommand(
+        "return ae.getAllItems(${filterJson ?: ""})"
+    )
     /**
      * 请求物品命令
      * @param itemName 物品名称

--- a/src/main/kotlin/entity/Cpu.kt
+++ b/src/main/kotlin/entity/Cpu.kt
@@ -21,7 +21,7 @@ import top.limbang.remoteoc.network.serializer.CpuCoreStatusSerializer
  */
 @Serializable
 data class CpuDetail(
-    val storage: Int,
+    val storage: String,
     val coprocessors: Int,
     val name: String,
     @Serializable(with = CpuCoreStatusSerializer::class)

--- a/src/main/kotlin/entity/Item.kt
+++ b/src/main/kotlin/entity/Item.kt
@@ -155,3 +155,15 @@ data class LocalizedData(
     val size: Long,
     val isFluid: Boolean = false
 )
+
+/**
+ * 物品查询数据实体
+ * 用于物品终端过滤查询
+ * @property name 唯一命名空间标识符
+ * @property damage 损伤值或元数据标识，用于区分同类物品的不同状态。
+ */
+@Serializable
+data class searchItem(
+    val name: String,
+    val damage: Int,
+)

--- a/src/main/kotlin/listener/ClientListener.kt
+++ b/src/main/kotlin/listener/ClientListener.kt
@@ -9,6 +9,7 @@ package top.limbang.remoteoc.listener
 
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.KSerializer
+
 import net.mamoe.mirai.contact.Contact.Companion.uploadImage
 import net.mamoe.mirai.event.EventHandler
 import net.mamoe.mirai.event.SimpleListenerHost
@@ -24,6 +25,8 @@ import top.limbang.remoteoc.listener.TeamListener.sendMessage
 import top.limbang.remoteoc.network.model.ResultData
 import top.limbang.remoteoc.utils.*
 import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -35,6 +38,7 @@ object ClientListener : SimpleListenerHost() {
     private val BIND_CLIENT_REGEX = """^绑定客户端\s?([a-zA-Z0-9]{2,16})(?:\s+(true|false))?""".toRegex()
     private val CRAFT_ITEM_REGEX = """^合成\s+([^\s\n]+(?:\s+[^\s\n]+)*?)(?:\s+(\d{1,12}))?$""".toRegex()
     private val CANCEL_CRAFTING_REGEX = """^取消合成\s+(.*)""".toRegex()
+    private val ITEM_QUERY_REGEX = """^物品终端\s+([^\s\n]+(?:\s+[^\s\n]+)*)$""".toRegex()
 
     // 物品本地化工具
     private val itemUtil = ItemUtil(dataFolderPath.toString())
@@ -154,6 +158,49 @@ object ClientListener : SimpleListenerHost() {
         result?.data ?: run { sendMessage("❌ 获取CPU信息失败"); return }
         // 发送CPU信息图片
         sendImage(result.data.toImage(itemUtil))
+    }
+    /**
+     * 物品终端查询功能
+     */
+    @EventHandler
+    suspend fun GroupMessageEvent.getAllItems() {
+        // 1. 确认消息包含 "物品终端"
+        val content = message.contentToString()
+        if (!ITEM_QUERY_REGEX.matches(content)) return
+
+        // 2. 获取团队信息
+        val team = validateTeamAndClient() ?: return
+
+
+        // 3. 获取所有查询的本地化名称
+        val queryItems = content.removePrefix("物品终端").trim().split(" ")
+        val items = itemUtil.searchItemsByNames(queryItems)
+
+        if (items.isEmpty()) {
+            sendMessage("❌ 数据库没有任何匹配的物品")
+            return
+        }
+
+        val allData = mutableListOf<LocalizedData>()
+
+        // 4. 批量处理物品查询
+        if(items.size < 2)
+        {
+            val firstItem = items.first()
+            val result = sendCommandRequest(team, AeCommand.GetSingleItem(firstItem.name,firstItem.damage), Item.serializer())
+            if (result?.data == null) return
+            allData.addAll(itemUtil.getLocalizedDataList(result.data))
+        }
+        else {
+            val result = sendCommandRequest(team, AeCommand.GetAllItems(convertToLuaTable(items)), Item.serializer())
+            if (result?.data == null) return
+            allData.addAll(itemUtil.getLocalizedDataList(result.data))
+        }
+
+        //返回图片
+        if (allData.isNotEmpty()) {
+            sendImage(allData.toImage("物品终端"))
+        }else sendMessage("❌ 未找到物品");
     }
 
     /**
@@ -278,6 +325,18 @@ object ClientListener : SimpleListenerHost() {
     }
 
     /**
+     * 将物品列表转换为 Lua 表格式
+     *
+     * @param items 待查询的物品列表
+     * @return Lua 表格式的字符串
+     */
+    private fun convertToLuaTable(items: List<searchItem>): String {
+        return items.joinToString(prefix = "{", postfix = "}") { item ->
+            val damagePart = item.damage?.let { ", damage=$it" } ?: ""
+            "{name=\"${item.name}\"$damagePart}"
+        }
+    }
+    /**
      * 发送命令请求
      *
      * @param T 命令返回类型
@@ -323,3 +382,5 @@ object ClientListener : SimpleListenerHost() {
     }
 
 }
+
+

--- a/src/main/kotlin/listener/ClientListener.kt
+++ b/src/main/kotlin/listener/ClientListener.kt
@@ -200,7 +200,7 @@ object ClientListener : SimpleListenerHost() {
 
         //返回图片
         if (allData.isNotEmpty()) {
-            sendImage(allData.toImage("物品终端"))
+            sendImage(allData.toImage("物品终端", cellsWidth = 120, columnCount = 4, cellHeight = 86))
         }else sendMessage("❌ 未找到物品");
     }
 
@@ -276,29 +276,34 @@ object ClientListener : SimpleListenerHost() {
             teamCraftables[team.name] ?: run { sendMessage("❌ 请先发送[合成终端]指令获取可合成物品清单"); return }
         // 查询物品是否可以合成
         // 尝试精确匹配
-        var localizedItem = craftItems.find { it.name == itemName }
+        var craftItem = craftItems.find { it.name == itemName }
 
-        // 如果精确匹配失败，尝试拼音匹配
-        if (localizedItem == null) {
-            val targetPinyin = Pinyin.toPinyin(itemName, "").replace(" ", "").lowercase()
-            localizedItem = craftItems.find {
-                val itemPinyin = Pinyin.toPinyin(it.name, "").replace(" ", "").lowercase()
-                itemPinyin == targetPinyin
+        // 如果精确匹配失败，使用拼音通配符匹配
+        if (craftItem == null) {
+            val normalizedInput = Pinyin.toPinyin(itemName, " ").replace(" ", "").lowercase()
+            val patternPinyin = if (itemName.contains("*")) {
+                normalizedInput.replace("*", ".*")
+            } else {
+                ".*${normalizedInput}.*"
+            }
+
+            craftItem = craftItems.sortedBy { it.name.startsWith(itemName) }.find {
+                val itemPinyin = Pinyin.toPinyin(it.name, " ").replace(" ", "").lowercase()
+                itemPinyin.matches(patternPinyin.toRegex())
             }
         }
 
         // 查询物品是否可以合成
-        localizedItem ?: run { sendMessage("❌ 该物品无法合成,发送[合成终端]刷新可合成物品清单"); return }
+        craftItem ?: run { sendMessage("❌ 该物品无法合成,发送[合成终端]刷新可合成物品清单"); return }
 
         // 发送合成请求
-        sendMessage("📤 合成[${localizedItem.name}*$countInt]正在发送合成请求，请等待结果")
-
+        sendMessage("📤 合成[${craftItem.name}*$countInt]正在发送合成请求，请等待结果")
         // 发送合成请求
         val result = sendCommandRequest(
             team = team,
             aeCommand = AeCommand.RequestItem(
-                itemName = localizedItem.id,
-                damage = localizedItem.damage,
+                itemName = craftItem.id,
+                damage = craftItem.damage,
                 amount = countInt
             ),
             serializer = CraftingData.serializer()
@@ -310,12 +315,12 @@ object ClientListener : SimpleListenerHost() {
             if (craftingData.failed) {
                 val failureReason = craftingData.canceled.why ?: "未知原因"
                 val failureMessage = when {
-                    failureReason.contains("missing resources") -> "❌ 合成失败：${localizedItem.name} 原因：缺少资源"
-                    else -> "❌ 合成失败：${localizedItem.name} 原因：$failureReason"
+                    failureReason.contains("missing resources") -> "❌ 合成失败：${craftItem.name} 原因：缺少资源"
+                    else -> "❌ 合成失败：${craftItem.name} 原因：$failureReason"
                 }
                 sendMessage(failureMessage)
             } else {
-                sendMessage("📥 [${localizedItem.name}*${countInt}]合成请求已发送，正在获取CPU信息,请等待结果")
+                sendMessage("📥 [${craftItem.name}*${countInt}]合成请求已发送，正在获取CPU信息,请等待结果")
                 sendCpuInfo(team)
             }
         }
@@ -396,5 +401,3 @@ object ClientListener : SimpleListenerHost() {
     }
 
 }
-
-

--- a/src/main/kotlin/listener/ClientListener.kt
+++ b/src/main/kotlin/listener/ClientListener.kt
@@ -10,6 +10,7 @@ package top.limbang.remoteoc.listener
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.KSerializer
 
+import com.github.promeg.pinyinhelper.Pinyin
 import net.mamoe.mirai.contact.Contact.Companion.uploadImage
 import net.mamoe.mirai.event.EventHandler
 import net.mamoe.mirai.event.SimpleListenerHost
@@ -274,10 +275,23 @@ object ClientListener : SimpleListenerHost() {
         val craftItems =
             teamCraftables[team.name] ?: run { sendMessage("❌ 请先发送[合成终端]指令获取可合成物品清单"); return }
         // 查询物品是否可以合成
-        val localizedItem =
-            craftItems.find { it.name == itemName } ?: run { sendMessage("❌ 该物品无法合成"); return }
+        // 尝试精确匹配
+        var localizedItem = craftItems.find { it.name == itemName }
+
+        // 如果精确匹配失败，尝试拼音匹配
+        if (localizedItem == null) {
+            val targetPinyin = Pinyin.toPinyin(itemName, "").replace(" ", "").lowercase()
+            localizedItem = craftItems.find {
+                val itemPinyin = Pinyin.toPinyin(it.name, "").replace(" ", "").lowercase()
+                itemPinyin == targetPinyin
+            }
+        }
+
+        // 查询物品是否可以合成
+        localizedItem ?: run { sendMessage("❌ 该物品无法合成,发送[合成终端]刷新可合成物品清单"); return }
+
         // 发送合成请求
-        sendMessage("📤 合成[$itemName*$countInt]正在发送合成请求，请等待结果")
+        sendMessage("📤 合成[${localizedItem.name}*$countInt]正在发送合成请求，请等待结果")
 
         // 发送合成请求
         val result = sendCommandRequest(

--- a/src/main/kotlin/utils/DeawTerminalUtil.kt
+++ b/src/main/kotlin/utils/DeawTerminalUtil.kt
@@ -14,6 +14,7 @@ import top.limbang.remoteoc.utils.MinecraftStyle.BORDER_HIGHLIGHT_COLOR
 import top.limbang.remoteoc.utils.MinecraftStyle.BORDER_SHADOW_COLOR
 import top.limbang.remoteoc.utils.MinecraftStyle.ITEM_TEXT_COLOR
 import java.awt.*
+import java.awt.SystemColor.text
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
@@ -25,8 +26,8 @@ import kotlin.math.ceil
  *
  * @param title 终端标题 默认为 "终端"
  * @param columnCount 列数 默认为 9
- * @param cellWidth 单元格宽度 默认为 64
- * @param cellHeight 单元格高度 默认为 64
+ * @param cellsWidth 单元格宽度 默认为 64
+ * @param cellHeight 单元格高度 默认为 0 表示与 cell为正方形
  * @param horizontalPadding 水平边距 默认为 20
  * @param bottomPadding 底部边距 默认为 20
  * @param headerHeight 标题高度 默认为 40
@@ -36,7 +37,7 @@ import kotlin.math.ceil
 fun List<LocalizedData>.toImage(
     title: String = "终端",
     columnCount: Int = 9,
-    cellWidth: Int = 64,
+    cellsWidth: Int = 0, // 0 表示与 cellHeight 相同
     cellHeight: Int = 64,
     horizontalPadding: Int = 20,
     bottomPadding: Int = 20,
@@ -45,6 +46,7 @@ fun List<LocalizedData>.toImage(
 ): BufferedImage {
 
     // 计算网格布局参数
+    val cellWidth = if (cellsWidth <= 0) cellHeight else maxOf(64, cellsWidth)
     val rowCount = ceil(size.toDouble() / columnCount).toInt()
     val canvasWidth = (cellWidth * columnCount) + (horizontalPadding * 2) + borderSize
     val canvasHeight = headerHeight + (cellHeight * rowCount) + bottomPadding + borderSize
@@ -121,32 +123,37 @@ private fun drawTableCell(g: Graphics2D, data: LocalizedData?, x: Int, y: Int, w
 
     // 若数据为 null，不需要绘制内容
     if (data == null) return
-
-    val iconSize = if (data.isFluid) 58 else 48
+    val iconSize = ((if (data.isFluid) 58 else 48) * (height/64.0)).toInt()
 
     // 加载并绘制图标
     val icon = try {
         ImageIO.read(File(data.imgPath)).getScaledInstance(iconSize, iconSize, Image.SCALE_SMOOTH)
     } catch (e: Exception) {
         // 图标加载失败，读取默认图标
-        getImage("default.png")!!
+        val defaultIcon = getImage("default.png")!!
+        val scaledDefaultIcon = (defaultIcon as BufferedImage).getScaledInstance(iconSize, iconSize, Image.SCALE_SMOOTH)
+        scaledDefaultIcon
     }
-    g.drawImage(icon, x + (width - iconSize) / 2, y + (height - iconSize) / 2, null)
+    g.drawImage(icon, x + 3, y + (height - iconSize) / 2, null)
 
-
-    // 绘制数据名称
-    g.color = Color.WHITE
-    g.font = Font("Microsoft YaHei", Font.PLAIN, 9)
-    g.drawString(truncateText(data.name, g.fontMetrics, 55), x + 5, y + 2 + g.fontMetrics.ascent)
+    if((width / height) < 3)
+    {
+        // 绘制数据名称
+        g.color = Color.WHITE
+        g.font = Font("Microsoft YaHei", Font.PLAIN, height/7)
+        g.drawString(truncateText(data.name, g.fontMetrics, width-9), x + 5, y + 2 + g.fontMetrics.ascent)
+    }
 
     // 获取字体度量信息
-    g.font = Font("Microsoft YaHei", Font.PLAIN, 12)
+    g.font = Font("Microsoft YaHei", Font.PLAIN, height/5)
     val fm = g.fontMetrics
-    val text = if (data.size < 1 && data.isCraftable) "合成" else NumberFormatter.format(data.size)
+    val textSize  = if (data.size > 0 || ((width*2 / height) > 3)) NumberFormatter.format(data.size) else ""
+    val textCraft = if(data.isCraftable) "合成" else ""
+    val text = textCraft+textSize
     val textWidth = fm.stringWidth(text)
 
     // 计算文本的绘制位置，确保右对齐并留有边距
-    val textX = x + width - 8 - textWidth // 右对齐，距离右边 8px
+    val textX = x + width - 6 - textWidth // 右对齐，距离右边 8px
     val textY = y + height - 4 - fm.descent // 确保底部间距 8px
 
     // 绘制合成或数量

--- a/src/main/kotlin/utils/DrawCpuUtil.kt
+++ b/src/main/kotlin/utils/DrawCpuUtil.kt
@@ -204,7 +204,9 @@ private fun drawCpuHeader(
     if (isDrawDetailedCpuStatus) {
         val cpuName = "CPU #${cpuDetail.name.ifEmpty { cpuNumber + 1 }}"
         val statusText = "状态: ${if (cpuDetail.busy) "忙碌中" else "空闲"}"
-        val storageText = "可存储: ${cpuDetail.storage / 1024} KB"
+        val storageText = cpuDetail.storage.toLongOrNull()?.let {
+            "可存储: ${it / 1024} KB"
+        } ?: "可存储: Infinity"
         val coresText = "并行处理单元: ${cpuDetail.coprocessors}"
         val fullText = listOf(cpuName, statusText, storageText, coresText).joinToString("  |  ")
 
@@ -391,7 +393,10 @@ fun List<CpuDetail>.drawCpuStatus(
         val iconY = infoY - 22
 
         g.drawImage(storageIcon, nameX, iconY, null)
-        g.drawString("${cpuDetail.storage / 1024} KB", firstTextX, infoY)
+        val storageText = cpuDetail.storage.toLongOrNull()?.let {
+            "${it / 1024} KB"
+        } ?: "Infinity"
+        g.drawString(storageText, firstTextX, infoY)
 
         g.drawImage(processorIcon, secondIconX, iconY, null)
         g.drawString("${cpuDetail.coprocessors}", secondTextX, infoY)

--- a/src/main/kotlin/utils/ItemUtil.kt
+++ b/src/main/kotlin/utils/ItemUtil.kt
@@ -173,7 +173,7 @@ class ItemUtil(
             }
 
             if (chineseResultCount < 2) {
-                val pinyinQuery = query.lowercase()
+                val pinyinQuery = Pinyin.toPinyin(query," ").replace(" ", "").lowercase()
                 if (pinyinQuery.contains("*")) {
                     // 拼音模糊查询
                     val regex = pinyinQuery.replace("*", ".*")
@@ -207,14 +207,15 @@ class ItemUtil(
      * 1. 从NBT标签解析流体名称
      * 2. 使用流体名称的本地化版本+"液滴"后缀
      * 3. 保持液滴自身材质路径逻辑不变
+     * 4. 不匹配物品时显示独立的滴液图标和本地化名字
      */
     private fun handleFluidDrop(item: Item): LocalizedData {
         // 处理缺少tag的情况,使用流体数据文件中的名称
         if (item.tag.isEmpty()) {
             val fluidName = item.label.removePrefix("drop of ").lowercase().replace(" ", ".")
             val fluidMetadata = fluidData[fluidName]
-            val fluidLocalizedName = fluidMetadata?.localizedName ?: fluidName
-            val fluidImgPath = "$resourceDir/image/${fluidMetadata?.imgPath ?: "default.png"}"
+            val fluidLocalizedName = fluidMetadata?.localizedName ?: fluidName.replace("drop.of.fluid.", "")
+            val fluidImgPath = "$resourceDir/image/${fluidMetadata?.imgPath ?: "defaultDrop.png"}"
             return LocalizedData(
                 id = item.name,
                 name = fluidLocalizedName,
@@ -239,7 +240,7 @@ class ItemUtil(
             ?.get(item.damage.toString())
             ?.imgPath
             ?.let { "$resourceDir/image/$it" }
-            ?: "$resourceDir/image/default.png"
+            ?: "$resourceDir/image/defaultDrop.png"
 
         return LocalizedData(
             id = item.name,
@@ -316,7 +317,10 @@ class ItemUtil(
      */
     @JvmName("getLocalizedDataListFromItems")
     fun getLocalizedDataList(items: List<Item>): List<LocalizedData> {
-        return items.map { getLocalizedData(it) }
+        //排序并本地化
+        return items
+            .sortedWith(compareBy<Item> { it.name }.thenBy { it.damage })
+            .map { getLocalizedData(it) }
     }
 
     /**

--- a/src/main/kotlin/utils/ItemUtil.kt
+++ b/src/main/kotlin/utils/ItemUtil.kt
@@ -60,8 +60,8 @@ class ItemUtil(
                     // 1. 构建原始名称索引
                     localizedIndex[entry.localizedName] = pair
 
-                    // 2. 生成拼音索引（处理多音字）
-                    val pinyin = generatePinyinVariations(entry.localizedName) // 只返回一个拼音变体
+                    /* 2. 生成拼音索引（无多音字处理） */
+                    val pinyin = generatePinyinVariations(entry.localizedName)
                     pinyinIndex.computeIfAbsent(pinyin) { mutableListOf() }.add(pair)
                 }
             }
@@ -72,16 +72,7 @@ class ItemUtil(
      * 生成拼音变体（处理多音字）
      */
     fun generatePinyinVariations(chinese: String): String {
-        val words = chinese.toCharArray()
-        val pinyinList = words.map { char ->
-            if (Pinyin.isChinese(char)) {
-                Pinyin.toPinyin(char).lowercase() // `拼音` 转 `pinyin`
-            } else {
-                char.toString().lowercase() // 非汉字直接保留
-            }
-        }
-        // 组合所有可能的拼音变体
-        return pinyinList.joinToString("") //setOf(pinyinList.joinToString(""), pinyinList.joinToString(" "))
+        return Pinyin.toPinyin(chinese," ").replace(" ", "").lowercase()
     }
 
     /**
@@ -136,7 +127,7 @@ class ItemUtil(
 //        }
 
         // 拼音模糊匹配
-        val pinyinQuery = query.lowercase()
+        val pinyinQuery = Pinyin.toPinyin(query," ").replace(" ", "").lowercase()
         pinyinIndex.filterKeys { it.contains(pinyinQuery) }.values.flatten().forEach { (name, damage) ->
             results.add(Item(name, damage = damage, label = query, size = 0))
         }

--- a/src/main/kotlin/utils/ItemUtil.kt
+++ b/src/main/kotlin/utils/ItemUtil.kt
@@ -8,6 +8,7 @@
 package top.limbang.remoteoc.utils
 
 
+import com.github.promeg.pinyinhelper.Pinyin
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import top.limbang.remoteoc.entity.*
@@ -36,6 +37,8 @@ class ItemUtil(
     private val itemData: Map<String, Map<String, ItemMetadata>>
     private val fluidData: Map<String, FluidMetadata>
 
+    private val localizedIndex = mutableMapOf<String, Pair<String, Int>>()
+    private val pinyinIndex = mutableMapOf<String, MutableList<Pair<String, Int>>>()
     init {
         // 检查资源目录是否存在
         val itemFile = File(resourceDir, itemJsonName).takeIf { it.exists() }
@@ -47,6 +50,38 @@ class ItemUtil(
         itemData = itemFile.reader(Charsets.UTF_8).use { json.decodeFromString(it.readText()) }
         // 加载液体数据,自动关闭流
         fluidData = fluidFile.reader(Charsets.UTF_8).use { json.decodeFromString(it.readText()) }
+
+        // 构建索引逻辑
+        itemData.forEach { (itemId, metas) ->
+            metas.forEach { (metaStr, entry) ->
+                metaStr.toIntOrNull()?.let { meta ->
+                    val pair = itemId to meta
+
+                    // 1. 构建原始名称索引
+                    localizedIndex[entry.localizedName] = pair
+
+                    // 2. 生成拼音索引（处理多音字）
+                    val pinyin = generatePinyinVariations(entry.localizedName) // 只返回一个拼音变体
+                    pinyinIndex.computeIfAbsent(pinyin) { mutableListOf() }.add(pair)
+                }
+            }
+        }
+    }
+
+    /**
+     * 生成拼音变体（处理多音字）
+     */
+    fun generatePinyinVariations(chinese: String): String {
+        val words = chinese.toCharArray()
+        val pinyinList = words.map { char ->
+            if (Pinyin.isChinese(char)) {
+                Pinyin.toPinyin(char).lowercase() // `拼音` 转 `pinyin`
+            } else {
+                char.toString().lowercase() // 非汉字直接保留
+            }
+        }
+        // 组合所有可能的拼音变体
+        return pinyinList.joinToString("") //setOf(pinyinList.joinToString(""), pinyinList.joinToString(" "))
     }
 
     /**
@@ -77,6 +112,92 @@ class ItemUtil(
         if (item.isFluidDrop()) return handleFluidDrop(item)
         // 常规物品处理流程
         return handleRegularItem(item)
+    }
+
+    /**
+     * 通过本地化名字或拼音查询 itemId 和 damage，支持模糊匹配
+     */
+    fun searchItemByName(query: String): List<Item> {
+        val results = mutableListOf<Item>()
+
+        // 中文直接查询
+//        localizedIndex[query]?.let {
+//            results.add(Item(name, damage = damage, label = query, size = 0))
+//        }
+        // 模糊匹配：查找包含 query 的本地化名称
+        localizedIndex.filterKeys { it.contains(query) }.values.forEach { (name, damage) ->
+            results.add(Item(name, damage = damage, label = query, size = 0))
+        }
+
+        // 拼音查询（支持多种拼音格式）
+//       val pinyinQuery = query.lowercase()
+//        pinyinIndex[pinyinQuery]?.let {
+//            results.add(Item(name, damage = damage, label = query, size = 0))
+//        }
+
+        // 拼音模糊匹配
+        val pinyinQuery = query.lowercase()
+        pinyinIndex.filterKeys { it.contains(pinyinQuery) }.values.flatten().forEach { (name, damage) ->
+            results.add(Item(name, damage = damage, label = query, size = 0))
+        }
+        return results.distinct()
+    }
+
+    fun searchItemsByNames(queries: List<String>): List<searchItem> {
+        val results = mutableListOf<searchItem>()
+        // 遍历每个查询
+        queries.forEach { query ->
+            var chineseResultCount = 0
+            val isChinese = query.any { Pinyin.isChinese(it) }
+
+            if (isChinese) {
+                if (query.contains("*")) {
+                    // 模糊查询
+                    val regex = query.replace("*", ".*") // 将 * 替换为 .*
+                    val pattern = Regex("^$regex$") // 添加 ^ 和 $ 确保匹配整个字符串
+                    localizedIndex.forEach { (key, value) ->
+                        if (pattern.matches(key)) {
+                            val item = searchItem(value.first, value.second)
+                            results.add(item)
+                            chineseResultCount++
+                        }
+                    }
+                } else {
+                    // 精确查询
+                    localizedIndex[query]?.let { (name, damage) ->
+                        val item = searchItem(name, damage)
+                        results.add(item)
+                        chineseResultCount++
+                    }
+                }
+            }
+
+            if (chineseResultCount < 2) {
+                val pinyinQuery = query.lowercase()
+                if (pinyinQuery.contains("*")) {
+                    // 拼音模糊查询
+                    val regex = pinyinQuery.replace("*", ".*")
+                    val pattern = Regex("^$regex$")
+                    pinyinIndex.forEach { (key, mappings) ->
+                        if (pattern.matches(key)) {
+                            mappings.forEach { (name, damage) ->
+                                results.add(searchItem(name, damage))
+                            }
+                        }
+                    }
+                } else {
+                    // 拼音精确查询
+                    pinyinIndex[pinyinQuery]?.let { mappings ->
+                        mappings.forEach { (name, damage) ->
+                            results.add(searchItem(name, damage))
+                        }
+                    }
+                }
+            }
+        }
+
+        // 返回去重后的结果
+        return results.distinct()
     }
 
     /**

--- a/src/test/kotlin/listener/ClientListenerTest.kt
+++ b/src/test/kotlin/listener/ClientListenerTest.kt
@@ -90,11 +90,11 @@ internal class ClientListenerTest {
 
         val result = sendCommandRequest(
             clientId = clientId,
-            aeCommand = AeCommand.GetAllItems(item),
+            aeCommand = AeCommand.GetSingleItem(item.name,item.damage),
             serializer = Item.serializer()
         )
         result?.data ?: run { logger.error("❌ 获取物品终端失败"); return@runBlocking }
-        val image = itemUtil.getLocalizedDataList(result.data!!).toImage("物品终端")
+        val image = itemUtil.getLocalizedDataList(result.data!!).toImage("[{name:\"minecraft:redstone\"},{name:\"minecraft:glass\"}]")
         ImageIO.write(image, "PNG", File("物品终端.png"))
         logger.info(result.data.toString())
     }

--- a/src/test/kotlin/utils/ItemUtilTest.kt
+++ b/src/test/kotlin/utils/ItemUtilTest.kt
@@ -1,6 +1,6 @@
 package top.limbang.remoteoc.utils
 
-import kotlinx.serialization.json.Json
+import junit.framework.TestCase.assertEquals
 import top.limbang.remoteoc.entity.Item
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -26,4 +26,119 @@ internal class ItemUtilTest {
     }
 
 
+}
+
+
+class PinyinTest {
+    private val itemUtil = ItemUtil("debug-sandbox/data/top.limbang.RemoteOC")
+
+    /**
+     * 测试纯中文字符（无多音字）
+     */
+    @Test
+    fun testAllChineseNoPolyphone() {
+        val input = "你好"
+        val expected = "nihao"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testAllChineseNoPolyphone: input = '$input', expected = $expected, result = $result")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试包含多音字的中文字符（假设库返回第一个拼音）
+     */
+    @Test
+    fun testChineseWithPolyphone() {
+        val input = "重庆"
+        // 假设 "重" 返回 "zhong"，"庆" 返回 "qing"
+        val expected = "zhongqing"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testChineseWithPolyphone: input = '$input', expected = $expected, result = $result")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试混合中英文、数字、符号
+     */
+    @Test
+    fun testMixedCharacters() {
+        val input = "a你b好123@"
+        val expected = "anibhao123@"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testMixedCharacters: input = '$input', expected = $expected, result = $result")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试空字符串
+     */
+    @Test
+    fun testEmptyString() {
+        val input = ""
+        val expected = ""  // 空字符串应该返回空字符串
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testEmptyString: input = '$input', expected = '$expected', result = '$result'")
+        assertEquals(expected, result)
+    }
+
+    /**
+     * 测试非中文字符（字母、数字）
+     */
+    @Test
+    fun testNonChineseCharacters() {
+        val input = "abc123"
+        val expected = "abc123"  // 直接返回拼音，不需要集合
+        val result = itemUtil.generatePinyinVariations(input)
+        println("testNonChineseCharacters: input = '$input', expected = '$expected', result = '$result'")
+        assertEquals(expected, result)
+    }
+}
+
+class ItemUtilTestByName {
+    private val itemUtil = ItemUtil("debug-sandbox/data/top.limbang.RemoteOC")
+
+    @Test
+    fun `test search item by exact name - silver wire`() {
+        val results = itemUtil.searchItemByName("1x银导线")
+        println("Search results for '1x银导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 100, label = "1x银导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+
+    }
+
+    @Test
+    fun `test search item by exact name - tin wire`() {
+        val results = itemUtil.searchItemByName("1x锡导线")
+        println("Search results for '1x锡导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 112, label = "1x锡导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
+
+    @Test
+    fun `test search item by exact name - tungsten wire`() {
+        val results = itemUtil.searchItemByName("1x钨导线")
+        println("Search results for '1x钨导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 115, label = "1x钨导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
+
+    @Test
+    fun `test search item by non-existent name`() {
+        val results = itemUtil.searchItemByName("1x金导线")  // 假设"金导线"不存在
+        println("Search results for '1x金导线': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 41, label = "1x金导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
+
+    @Test
+    fun `test search item by pinyin with different case`() {
+        val results = itemUtil.searchItemByName("jindaoxian")  // 拼音的不同大小写
+        println("Search results for 'jindaoxian': $results")
+        val expectedItem = Item(name = "gregtech:wire_single", damage = 41, label = "1x金导线", size = 0)
+        assertTrue(results.any { item -> item.name == expectedItem.name && item.damage == expectedItem.damage })
+        // 验证列表是否包含至少一个匹配的 Item
+    }
 }


### PR DESCRIPTION
增加物品终端指令,因为OC内存限制,仅支持物品过滤查询
1. 使用方法: 物品终端 [过滤1] [过滤2]...  
2. 支持使用全拼代替汉字; 汉字不匹配时, 会尝试使用输入汉字的拼音进行查询
3. 使用* 进行模糊匹配
例如: 物品终端 hongshi 铁*   可以过滤终端中的红石, 铁锭\铁块\铁砧\铁门 等 并返回
需要同步更新ae.lua 以支持多物品查询